### PR TITLE
Simplified pingpong examples

### DIFF
--- a/Solutions/c/ex2-pingpong/pingpong.c
+++ b/Solutions/c/ex2-pingpong/pingpong.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * An MPI program to send a message back and forth between two ranks
- *  using a blocking, synchronous send mpi_ssend(), and a blocking
+ *  using a blocking send mpi_send(), and a blocking
  *  recieve mpi_recv().
  *
  ******************************************************************************/
@@ -46,7 +46,7 @@ int main (int argc, char* argv[]){
         recver = 1 - sender;
 
         if ( rank == sender ){
-        	MPI_Ssend(&sendbuffer, 1, MPI_INT, recver, my_tag, MPI_COMM_WORLD);
+        	MPI_Send(&sendbuffer, 1, MPI_INT, recver, my_tag, MPI_COMM_WORLD);
         }
         else {
         	MPI_Recv(&recvbuffer, 1, MPI_INT, sender, my_tag, MPI_COMM_WORLD, &status);

--- a/Solutions/fortran/ex2-pingpong/pingpong.f90
+++ b/Solutions/fortran/ex2-pingpong/pingpong.f90
@@ -1,7 +1,7 @@
 program pingpong
 
   ! An MPI program to send a message back and forth between two ranks
-  ! using a blocking, synchronous send mpi_ssend(), and a blocking
+  ! using a blocking send mpi_send(), and a blocking
   ! recieve mpi_recv().
 
   use mpi
@@ -42,7 +42,7 @@ program pingpong
      recver = 1 - sender
 
      if (rank == sender) then
-        call mpi_ssend(sendbuffer, 1, MPI_INTEGER, recver, my_tag, &
+        call mpi_send(sendbuffer, 1, MPI_INTEGER, recver, my_tag, &
                        MPI_COMM_WORLD, ifail)
      else
         call mpi_recv(recvbuffer, 1, MPI_INTEGER, sender, my_tag, &


### PR DESCRIPTION
While MPI_Ssend, synchronous send may be a preferred option for blocking
send and receives, it's overly complicated for an intro course.  Changed
C and Fortran examples to just MPI_Send